### PR TITLE
Fix image display issue

### DIFF
--- a/src/components/prebuilt/PreBuiltPCCard.tsx
+++ b/src/components/prebuilt/PreBuiltPCCard.tsx
@@ -11,58 +11,58 @@ const getImagesForConfig = (configId: string): { cpu: string; gpu: string } => {
   switch (configId) {
     case "budget1":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R5 5600.png",
-        gpu: "/src/components/prebuilt/pc-parts/6650XT.png"
+        cpu: "/pc-parts/R5 5600.png",
+        gpu: "/pc-parts/6650XT.png"
       };
     case "budget2":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R5 5600.png",
-        gpu: "/src/components/prebuilt/pc-parts/6750XT.png"
+        cpu: "/pc-parts/R5 5600.png",
+        gpu: "/pc-parts/6750XT.png"
       };
     case "mid1":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R5 5600.png",
-        gpu: "/src/components/prebuilt/pc-parts/4060 EAGLE 3X.png"
+        cpu: "/pc-parts/R5 5600.png",
+        gpu: "/pc-parts/4060 EAGLE 3X.png"
       };
     case "mid2":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R7 5800X.png",
-        gpu: "/src/components/prebuilt/pc-parts/7700XT GIGABYTE GAMING OC.png"
+        cpu: "/pc-parts/R7 5800X.png",
+        gpu: "/pc-parts/7700XT GIGABYTE GAMING OC.png"
       };
     case "high1":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/i5-14600KF.png",
-        gpu: "/src/components/prebuilt/pc-parts/7800XT POWERCOLOR HELLBOUND.png"
+        cpu: "/pc-parts/i5-14600KF.png",
+        gpu: "/pc-parts/7800XT POWERCOLOR HELLBOUND.png"
       };
     case "high2":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/i5-14600KF.png",
-        gpu: "/src/components/prebuilt/pc-parts/4070 SUPER TWIN EDGE ZOTAC.png"
+        cpu: "/pc-parts/i5-14600KF.png",
+        gpu: "/pc-parts/4070 SUPER TWIN EDGE ZOTAC.png"
       };
     case "extreme1":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/i7-14700KF.png",
-        gpu: "/src/components/prebuilt/pc-parts/4070 Ti SUPER PNY EPIC-X RGB.png"
+        cpu: "/pc-parts/i7-14700KF.png",
+        gpu: "/pc-parts/4070 Ti SUPER PNY EPIC-X RGB.png"
       };
     case "extreme2":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R7 7800X3D.png",
-        gpu: "/src/components/prebuilt/pc-parts/7900XTX TAICHI.png"
+        cpu: "/pc-parts/R7 7800X3D.png",
+        gpu: "/pc-parts/7900XTX TAICHI.png"
       };
     case "extreme3":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/i9-14900KF.png",
-        gpu: "/src/components/prebuilt/pc-parts/4080 SUPER PNY EPIC-X RGB.png"
+        cpu: "/pc-parts/i9-14900KF.png",
+        gpu: "/pc-parts/4080 SUPER PNY EPIC-X RGB.png"
       };
     case "extreme4":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R7 9800X3D.png",
-        gpu: "/src/components/prebuilt/pc-parts/7900XTX TAICHI.png"
+        cpu: "/pc-parts/R7 9800X3D.png",
+        gpu: "/pc-parts/7900XTX TAICHI.png"
       };
     case "extreme5":
       return {
-        cpu: "/src/components/prebuilt/pc-parts/R7 9800X3D.png",
-        gpu: "/src/components/prebuilt/pc-parts/4080 SUPER MSI GAMING X SLIM.png"
+        cpu: "/pc-parts/R7 9800X3D.png",
+        gpu: "/pc-parts/4080 SUPER MSI GAMING X SLIM.png"
       };
     default:
       return {


### PR DESCRIPTION
Addressed the problem where placeholder images were being displayed instead of the intended images from the pc-parts directory. [skip gpt_engineer]